### PR TITLE
Add privacy policy and terms pages

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-danger */
 /* -------------------------------------------------------------------------- */
 /*  src/app/page.tsx                                                          */
 /* -------------------------------------------------------------------------- */
@@ -417,7 +416,7 @@ export default function Page() {
           {[
             {
               q: "How long does a brief take to generate?",
-              a: "Around 30 seconds!",
+              a: "Around 45 seconds!",
             },
             {
               q: "What data sources are used?",
@@ -442,8 +441,16 @@ export default function Page() {
 
       {/* FOOTER ------------------------------------------------------------- */}
       <footer className="bg-white border-t border-slate-200">
-        <div className="max-w-6xl mx-auto px-4 py-10 flex flex-col sm:flex-row justify-between text-sm text-slate-500">
+        <div className="max-w-6xl mx-auto px-4 py-10 flex flex-col sm:flex-row justify-between text-sm text-slate-500 gap-4">
           <p>© {new Date().getFullYear()} MeetingBrief</p>
+          <div className="flex gap-4">
+            <Link href="/privacy" className="hover:text-indigo-600">
+              Privacy Policy
+            </Link>
+            <Link href="/terms" className="hover:text-indigo-600">
+              Terms of Service
+            </Link>
+          </div>
         </div>
       </footer>
     </div>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,33 @@
+export const metadata = {
+  title: "Privacy Policy - MeetingBrief",
+};
+
+export default function PrivacyPolicy() {
+  return (
+    <div className="min-h-screen bg-white">
+      <main className="max-w-3xl mx-auto px-4 py-12 space-y-6">
+        <h1 className="text-3xl font-semibold">Privacy Policy</h1>
+        <p>
+          IntelEngine (&quot;we&quot;, &quot;us&quot;, or &quot;our&quot;) operates the MeetingBrief
+          service.
+        </p>
+        <p>
+          This policy explains how we handle information you provide when using
+          our site. We may collect names, organizations and other details you
+          enter solely to generate meeting briefs.
+        </p>
+        <p>
+          We do not share or sell your personal data with third parties. We use
+          the information only to deliver the requested service and improve our
+          product. Information may be stored with our service providers who are
+          contractually obligated to protect it.
+        </p>
+        <p>
+          You may contact us at <a href="mailto:ryan@meetingbrief.com" className="text-blue-600 underline">ryan@meetingbrief.com</a> or call
+          <a href="tel:+12064573039" className="text-blue-600 underline">(206) 457-3039</a> with any privacy questions.
+        </p>
+        <p>Effective date: June 1, 2024.</p>
+      </main>
+    </div>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,28 @@
+export const metadata = {
+  title: "Terms of Service - MeetingBrief",
+};
+
+export default function TermsOfService() {
+  return (
+    <div className="min-h-screen bg-white">
+      <main className="max-w-3xl mx-auto px-4 py-12 space-y-6">
+        <h1 className="text-3xl font-semibold">Terms of Service</h1>
+        <p>
+          By accessing or using MeetingBrief, you agree to these terms. IntelEngine
+          provides this service &quot;as is&quot; without warranties of any kind.
+        </p>
+        <p>
+          You are responsible for any content you submit. We do not guarantee the accuracy of information provided and are not liable for any damages arising from use of the service.
+        </p>
+        <p>
+          We may update these terms at any time. Continued use constitutes acceptance of the revised terms.
+        </p>
+        <p>
+          For support, email <a href="mailto:ryan@meetingbrief.com" className="text-blue-600 underline">ryan@meetingbrief.com</a> or call
+          <a href="tel:+12064573039" className="text-blue-600 underline">(206) 457-3039</a>.
+        </p>
+        <p>Effective date: June 1, 2024.</p>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/privacy` and `/terms` pages with IntelEngine contact details
- link to new policy pages in footer
- escape quotes so lint passes and update FAQ timing text

## Testing
- `pnpm lint` *(fails: next not found)*