### PR TITLE
Add clipboard copy for brief

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
+import { Toaster } from "@/components/ui/sonner";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -32,6 +33,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
+        <Toaster />
         {/* Vercel Analytics (loads after main content) */}
         <Analytics />
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import Link from "next/link";
 import {
   Card,
   CardHeader,
+  CardAction,
   CardTitle,
   CardDescription,
   CardContent,
@@ -18,6 +19,7 @@ import { Label } from "@/components/ui/label";
 import { Loader2, CheckCircle2 } from "lucide-react";
 import { motion } from "framer-motion";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { toast } from "sonner";
 
 /* -------------------------------------------------------------------------- */
 /*  Supabase client (public keys only)                                        */
@@ -217,6 +219,34 @@ export default function Page() {
     }
   };
 
+  const copyHtml = async () => {
+    if (!briefHtml) return;
+    try {
+      if (navigator.clipboard && "write" in navigator.clipboard) {
+        const type = "text/html";
+        const blob = new Blob([briefHtml], { type });
+        await navigator.clipboard.write([
+          new ClipboardItem({ [type]: blob }),
+        ]);
+      } else {
+        const el = document.createElement("div");
+        el.innerHTML = briefHtml;
+        document.body.appendChild(el);
+        const range = document.createRange();
+        range.selectNodeContents(el);
+        const sel = window.getSelection();
+        sel?.removeAllRanges();
+        sel?.addRange(range);
+        document.execCommand("copy");
+        sel?.removeAllRanges();
+        document.body.removeChild(el);
+      }
+      toast("Brief copied to clipboard");
+    } catch (err) {
+      toast("Failed to copy");
+    }
+  };
+
   /* ─────────────── view */
   return (
     <div className="min-h-screen flex flex-col">
@@ -324,6 +354,11 @@ export default function Page() {
                     <CheckCircle2 className="inline h-5 w-5 text-green-600" />
                   </CardTitle>
                   <CardDescription>Scroll or copy as needed</CardDescription>
+                  <CardAction>
+                    <Button size="sm" variant="outline" onClick={copyHtml}>
+                      Copy Brief
+                    </Button>
+                  </CardAction>
                 </CardHeader>
                 <CardContent className="prose prose-lg prose-slate max-w-none text-left prose-li:marker:text-slate-600">
                   <div


### PR DESCRIPTION
## Summary
- support toast notifications globally
- allow copying generated HTML to the clipboard

## Testing
- `npm run lint` *(fails: next not found)*