### PR TITLE
Fix clipboard copy error log

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -243,7 +243,7 @@ export default function Page() {
       }
       toast("Brief copied to clipboard");
     } catch (err) {
-      console.error(err);
+      console.error("Copy to clipboard failed:", err);
       toast("Failed to copy");
     }
   };


### PR DESCRIPTION
## Summary
- log an explicit message when copying the brief fails

## Testing
- `pnpm lint` *(fails: `next: not found`)*
- `pnpm build` *(fails: `next: not found`)*