### PR TITLE
Add PDF export option

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -243,8 +243,33 @@ export default function Page() {
       }
       toast("Brief copied to clipboard");
     } catch (err) {
-      console.error(err);
+      console.error("Copy to clipboard failed:", err);
       toast("Failed to copy");
+    }
+  };
+
+  const downloadPdf = async () => {
+    if (!briefHtml) return;
+    try {
+      if (!(window as any).html2pdf) {
+        await new Promise((resolve, reject) => {
+          const script = document.createElement("script");
+          script.src =
+            "https://cdn.jsdelivr.net/npm/html2pdf.js@0.10.1/dist/html2pdf.bundle.min.js";
+          script.onload = resolve;
+          script.onerror = reject;
+          document.body.appendChild(script);
+        });
+      }
+      const element = document.getElementById("brief-content");
+      if (element && (window as any).html2pdf) {
+        (window as any).html2pdf().from(element).save("meeting-brief.pdf");
+      } else {
+        throw new Error("PDF library failed to load");
+      }
+    } catch (err) {
+      console.error("PDF download failed:", err);
+      toast("Failed to download PDF");
     }
   };
 
@@ -359,10 +384,19 @@ export default function Page() {
                     <Button size="sm" variant="outline" onClick={copyHtml}>
                       Copy Brief
                     </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={downloadPdf}
+                      className="ml-2"
+                    >
+                      Download PDF
+                    </Button>
                   </CardAction>
                 </CardHeader>
                 <CardContent className="prose prose-lg prose-slate max-w-none text-left prose-li:marker:text-slate-600">
                   <div
+                    id="brief-content"
                     dangerouslySetInnerHTML={{ __html: briefHtml }}
                   />
                 </CardContent>


### PR DESCRIPTION
## Summary
- add function to download brief as PDF via html2pdf.js CDN
- add "Download PDF" button next to "Copy Brief"
- mark brief container with `id="brief-content"` for export

## Testing
- `pnpm lint` *(fails: `next` not found)*
- `pnpm build` *(fails: `next` not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.